### PR TITLE
Some adjustments to simplify ingestion of data

### DIFF
--- a/geospaas/base_viewer/apps.py
+++ b/geospaas/base_viewer/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class BaseViewerConfig(AppConfig):
-    name = 'base_viewer'
+    name = 'geospaas.base_viewer'

--- a/geospaas/base_viewer/apps.py
+++ b/geospaas/base_viewer/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class BaseViewerConfig(AppConfig):
     name = 'geospaas.base_viewer'
-    default_auto_field = "django.db.models.BigAutoField"
+    default_auto_field = "django.db.models.AutoField"

--- a/geospaas/base_viewer/views.py
+++ b/geospaas/base_viewer/views.py
@@ -41,7 +41,7 @@ class IndexView(View):
     @classmethod
     def get_all_datasets(cls):
         """ Retrieve all dataset(s) from the database"""
-        return Dataset.objects.order_by('time_coverage_start')
+        return Dataset.objects.order_by('time_coverage_start').exclude(geographic_location__isnull=True)
 
     @classmethod
     def get_filtered_datasets(cls, form):

--- a/geospaas/catalog/__init__.py
+++ b/geospaas/catalog/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'geospaas.catalog.apps.CatalogConfig'

--- a/geospaas/catalog/apps.py
+++ b/geospaas/catalog/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class BaseViewerConfig(AppConfig):
-    name = 'geospaas.base_viewer'
+class CatalogConfig(AppConfig):
+    name = "geospaas.catalog"
     default_auto_field = "django.db.models.BigAutoField"

--- a/geospaas/catalog/apps.py
+++ b/geospaas/catalog/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class CatalogConfig(AppConfig):
     name = "geospaas.catalog"
-    default_auto_field = "django.db.models.BigAutoField"
+    default_auto_field = "django.db.models.AutoField"

--- a/geospaas/nansat_ingestor/__init__.py
+++ b/geospaas/nansat_ingestor/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'geospaas.nansat_ingestor.apps.NansatIngestorConfig'

--- a/geospaas/nansat_ingestor/apps.py
+++ b/geospaas/nansat_ingestor/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class NansatIngestorConfig(AppConfig):
+    name = "geospaas.nansat_ingestor"
+    default_auto_field = "django.db.models.BigAutoField"

--- a/geospaas/nansat_ingestor/apps.py
+++ b/geospaas/nansat_ingestor/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class NansatIngestorConfig(AppConfig):
     name = "geospaas.nansat_ingestor"
-    default_auto_field = "django.db.models.BigAutoField"
+    default_auto_field = "django.db.models.AutoField"

--- a/geospaas/nansat_ingestor/management/commands/ingest_thredds_crawl.py
+++ b/geospaas/nansat_ingestor/management/commands/ingest_thredds_crawl.py
@@ -38,7 +38,7 @@ def crawl_and_ingest(url, **options):
             # Create Dataset from OPeNDAP url - this is necessary to get all metadata
             gds, cr = NansatDataset.objects.get_or_create(url, uri_service_name=name,
                                                           uri_service_type=service)
-        except (IOError, AttributeError) as e:
+        except (IOError, AttributeError, ValueError) as e:
             # warnings.warn(e.message)
             continue
         if cr:

--- a/geospaas/nansat_ingestor/managers.py
+++ b/geospaas/nansat_ingestor/managers.py
@@ -1,6 +1,6 @@
 import json
+import logging
 import uuid
-import warnings
 
 import pythesint as pti
 from django.contrib.gis.geos import WKTReader
@@ -100,7 +100,7 @@ class DatasetManager(models.Manager):
             existing_ds = None
         for name in default_char_fields:
             if name not in n_metadata:
-                warnings.warn('%s is not provided in Nansat metadata!' % name)
+                logging.debug('%s is not provided in Nansat metadata!' % name)
                 # prevent overwriting of existing values by defaults
                 if existing_ds:
                     options[name] = existing_ds.__getattribute__(name)
@@ -123,12 +123,12 @@ class DatasetManager(models.Manager):
             value = default_foreign_keys[name]['value']
             model = default_foreign_keys[name]['model']
             if name not in n_metadata:
-                warnings.warn('%s is not provided in Nansat metadata!' % name)
+                logging.debug('%s is not provided in Nansat metadata!' % name)
             else:
                 try:
                     value = json.loads(n_metadata[name])
                 except:
-                    warnings.warn('%s value of %s  metadata provided in Nansat is wrong!' %
+                    logging.debug('%s value of %s  metadata provided in Nansat is wrong!' %
                                   (n_metadata[name], name))
             if existing_ds:
                 options[name] = existing_ds.__getattribute__(name)

--- a/geospaas/nansat_ingestor/managers.py
+++ b/geospaas/nansat_ingestor/managers.py
@@ -113,7 +113,7 @@ class DatasetManager(models.Manager):
             'gcmd_location': {'model': Location,
                               'value': pti.get_gcmd_location('SEA SURFACE')},
             'data_center': {'model': DataCenter,
-                            'value': pti.get_gcmd_provider('NERSC')},
+                            'value': pti.get_gcmd_provider('NO/MET')},
             'ISO_topic_category': {'model': ISOTopicCategory,
                                    'value': pti.get_iso19115_topic_category('Oceans')},
         }

--- a/geospaas/nansat_ingestor/managers.py
+++ b/geospaas/nansat_ingestor/managers.py
@@ -70,14 +70,14 @@ class DatasetManager(models.Manager):
             pp_dict = json.loads(pp)
         except json.JSONDecodeError:
             pp_entry = [elem.strip() for elem in pp.split('>')]
-            pp_dict = pti.get_gcmd_platform(pp_entry[-1])
+            pp_dict = pti.get_gcmd_platform(pp_entry[-1].split('(')[1][0:-1])
         platform, _ = Platform.objects.get_or_create(pp_dict)
         ii = n_metadata['instrument']
         try:
             ii_dict = json.loads(ii)
         except json.JSONDecodeError:
             ii_entry = [elem.strip() for elem in ii.split('>')]
-            ii_dict = pti.get_gcmd_instrument(ii_entry[-1])
+            ii_dict = pti.get_gcmd_instrument(ii_entry[-1].split('(')[1][0:-1])
         instrument, _ = Instrument.objects.get_or_create(ii_dict)
         specs = n_metadata.get('specs', '')
         source, _ = Source.objects.get_or_create(platform=platform,

--- a/geospaas/utils/utils.py
+++ b/geospaas/utils/utils.py
@@ -25,8 +25,14 @@ def module_path(module, root):
     return media_path
 
 
-def path(module, filename, root):
+def path(module, filename, root, date=None):
     mp = module_path(module, root)
+
+    if date is not None:
+        for xx in [date.strftime('%Y'), date.strftime('%m'), date.strftime('%d')]:
+            mp = os.path.join(mp, xx)
+            if not os.path.exists(mp):
+                os.mkdir(mp)
 
     # Get the path of media files created from <filename>
     basename = os.path.split(filename)[-1].split('.')[0]
@@ -39,8 +45,8 @@ def path(module, filename, root):
 def media_path(module, filename):
     return path(module, filename, settings.MEDIA_ROOT)
 
-def product_path(module, filename):
-    return path(module, filename, settings.PRODUCTS_ROOT)
+def product_path(module, filename, date=None):
+    return path(module, filename, settings.PRODUCTS_ROOT, date=date)
 
 def validate_uri(uri):
     """ Validation of URI and its existence

--- a/geospaas/utils/utils.py
+++ b/geospaas/utils/utils.py
@@ -1,5 +1,6 @@
 ''' Utility functions to perform common operations '''
 import os
+import logging
 from netCDF4 import Dataset
 
 try:
@@ -16,12 +17,19 @@ except ImportError:
 
 from django.conf import settings
 
+def create_folder(folder):
+    try:
+        os.mkdir(folder)
+    except FileExistsError:
+        logging.debug(f"{folder} already exists.")
+
+
 def module_path(module, root):
     media_path = root
     for m in module.split('.'):
         media_path = os.path.join(media_path, m)
         if not os.path.exists(media_path):
-            os.mkdir(media_path)
+            create_folder(media_path)
     return media_path
 
 
@@ -32,13 +40,13 @@ def path(module, filename, root, date=None):
         for xx in [date.strftime('%Y'), date.strftime('%m'), date.strftime('%d')]:
             mp = os.path.join(mp, xx)
             if not os.path.exists(mp):
-                os.mkdir(mp)
+                create_folder(mp)
 
     # Get the path of media files created from <filename>
     basename = os.path.split(filename)[-1].split('.')[0]
     dataset_path = os.path.join(mp, basename)
     if not os.path.exists(dataset_path):
-        os.mkdir(dataset_path)
+        create_folder(dataset_path)
 
     return dataset_path
 

--- a/geospaas/vocabularies/__init__.py
+++ b/geospaas/vocabularies/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'geospaas.vocabularies.apps.VocabulariesConfig'

--- a/geospaas/vocabularies/apps.py
+++ b/geospaas/vocabularies/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class BaseViewerConfig(AppConfig):
-    name = 'geospaas.base_viewer'
+class VocabulariesConfig(AppConfig):
+    name = "geospaas.vocabularies"
     default_auto_field = "django.db.models.BigAutoField"

--- a/geospaas/vocabularies/apps.py
+++ b/geospaas/vocabularies/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class VocabulariesConfig(AppConfig):
     name = "geospaas.vocabularies"
-    default_auto_field = "django.db.models.BigAutoField"
+    default_auto_field = "django.db.models.AutoField"

--- a/geospaas/vocabularies/management/commands/update_vocabularies.py
+++ b/geospaas/vocabularies/management/commands/update_vocabularies.py
@@ -35,15 +35,16 @@ class Command(BaseCommand):
         models = [
             Parameter,
             DataCenter,
-            HorizontalDataResolution,
+            #HorizontalDataResolution,
             Instrument,
             ISOTopicCategory,
             Location,
             Platform,
-            Project,
+            #Project,
             ScienceKeyword,
-            TemporalDataResolution,
-            VerticalDataResolution]
+            #TemporalDataResolution,
+            #VerticalDataResolution,
+            ]
 
         for model in models:
             model.objects.create_from_vocabularies(**options)

--- a/geospaas/vocabularies/managers.py
+++ b/geospaas/vocabularies/managers.py
@@ -61,7 +61,11 @@ class VocabularyManager(models.Manager):
 
     def get_or_create(self, entry, *args, **kwargs):
         """ Get or create database instance from input pythesint entry """
-        params = {key : entry[self.mapping[key]] for key in self.mapping}
+        try:
+            params = {key : entry[self.mapping[key]] for key in self.mapping}
+        except:
+            import ipdb
+            ipdb.set_trace()
         return super(VocabularyManager, self).get_or_create(**params)
 
     def create_from_vocabularies(self, force=False, **kwargs):
@@ -116,11 +120,21 @@ class ParameterManager(VocabularyManager):
 class PlatformManager(VocabularyManager):
     get_list = pti.get_gcmd_platform_list
     update = pti.update_gcmd_platform
-    mapping = dict(category='Category',
-                    series_entity='Series_Entity',
+    # mapping = dict(category='Category',
+    #                 series_entity='Series_Entity',
+    #                 short_name='Short_Name',
+    #                 long_name='Long_Name')
+    # New mapping to adapt to changes in GCMD
+    mapping = dict(category='Basis',
+                    series_entity='Category',
                     short_name='Short_Name',
                     long_name='Long_Name')
-
+    # Correct mapping needs update of tables..:
+    # mapping = dict(basis='Basis',
+    #                category='Category',
+    #                sub_category='Sub_Category',
+    #                short_name='Short_Name',
+    #                long_name='Long_Name')
 
 
 class InstrumentManager(VocabularyManager):

--- a/geospaas/vocabularies/managers.py
+++ b/geospaas/vocabularies/managers.py
@@ -52,13 +52,15 @@ class VocabularyManager(models.Manager):
         """
         num = 0
         for entry in pti_list:
-            pp, created = self.get_or_create(entry)
+            if bool(entry):
+                pp, created = self.get_or_create(entry)
+            else:
+                created = False
             if created: num+=1
         print("Successfully added %d new entries" % num)
 
     def get_or_create(self, entry, *args, **kwargs):
         """ Get or create database instance from input pythesint entry """
-
         params = {key : entry[self.mapping[key]] for key in self.mapping}
         return super(VocabularyManager, self).get_or_create(**params)
 


### PR DESCRIPTION
NetCDF files from MET uses ACDD as attribute convention. This is different from DIF in, e.g., that the unique id is called just `id` while in DIF it is `entry_id`. This update allows `id` if `entry_id` is not present.

In nansat, we generally just parse the json string representation of the gcmd keywords. A more readable format is, e.g., "Earth Remote Sensing Instruments > Active Remote Sensing > Imaging Radars > SAR > Synthetic Aperture Radar". This update also allows for that.